### PR TITLE
Update PepperBoxLoadGenTest.java

### DIFF
--- a/src/test/java/com/gslab/pepper/test/PepperBoxLoadGenTest.java
+++ b/src/test/java/com/gslab/pepper/test/PepperBoxLoadGenTest.java
@@ -42,7 +42,7 @@ public class PepperBoxLoadGenTest {
     private ZkClient zkClient = null;
 
     @Before
-    public void setup() throws IOException {
+    public void setUp() throws IOException {
 
         zkServer = new EmbeddedZookeeper();
 
@@ -95,7 +95,7 @@ public class PepperBoxLoadGenTest {
     }
 
     @After
-    public void teardown(){
+    public void tearDown(){
         kafkaServer.shutdown();
         zkClient.close();
         zkServer.shutdown();


### PR DESCRIPTION
JUnit framework methods (setUp and tearDown) have been misspelt.